### PR TITLE
add links to product examples and main page

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { CartIcon } from '@tipser/tipser-elements';
 import logo from '../logo.svg';
 
@@ -9,7 +10,14 @@ export class Header extends React.Component {
             <nav className="navigation">
                 <ul className="horizontal-menu">
                     <li className="horizontal-item">
-                        <img src={logo} className="te-logo" alt="logo" />
+                        <Link to="/"><img src={logo} className="te-logo" alt="logo" /></Link>
+                    </li>
+
+                    <li className="horizontal-item">
+                        <Link to="/product/5a1ad987b301420bbce8e976">Example product #1</Link>
+                    </li>
+                    <li className="horizontal-item">
+                        <Link to="/product/5c6d719d3b777f0001dffd36">Example product #2</Link>
                     </li>
                     <li className="horizontal-item">
                         <a


### PR DESCRIPTION
**Goal**
Being able to navigate to product pages and main page.

**GIF**
![Nagranie z ekranu 2019-04-16 o 14 37 15](https://user-images.githubusercontent.com/3996881/56210133-713fbd00-6055-11e9-8cb9-0dca9707f581.gif)

**Some comments**
"Product Example #X" link should most probably have different styling then links that navigates user from the page (like "Tipser Development"). That will be done - if will be - in a separate PR.